### PR TITLE
8088418: Reintroduce JFR Pulse Logger

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRInputEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRInputEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.logging.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("javafx.Input")
+@Label("JavaFX Input")
+@Category("JavaFX")
+@Description("JavaFX input event")
+@StackTrace(false)
+@Enabled(false)
+public final class JFRInputEvent extends Event {
+    @Label("Input Type")
+    @Description("Input event type")
+    private String input;
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javafx.logging.jfr;
+
+import com.sun.javafx.logging.Logger;
+import com.sun.javafx.logging.PulseLogger;
+
+import jdk.jfr.FlightRecorder;
+
+public final class JFRPulseLogger extends Logger {
+    private final ThreadLocal<JFRPulsePhaseEvent> currentPulsePhaseEvent;
+    private final ThreadLocal<JFRInputEvent> currentInputEvent;
+
+    private int pulseNumber;
+    private int fxPulseNumber;
+    private int renderPulseNumber;
+    private Thread fxThread;
+
+    public static Logger createInstance() {
+        if (FlightRecorder.isInitialized() || PulseLogger.isPulseLoggingRequested()) {
+            return new JFRPulseLogger();
+        }
+        return null;
+    }
+
+    private JFRPulseLogger() {
+        FlightRecorder.register(JFRInputEvent.class);
+        FlightRecorder.register(JFRPulsePhaseEvent.class);
+        currentPulsePhaseEvent = new ThreadLocal<JFRPulsePhaseEvent>() {
+            @Override
+            public JFRPulsePhaseEvent initialValue() {
+                return new JFRPulsePhaseEvent();
+            }
+        };
+        currentInputEvent = new ThreadLocal<JFRInputEvent>() {
+            @Override
+            public JFRInputEvent initialValue() {
+                return new JFRInputEvent();
+            }
+        };
+    }
+
+    @Override
+    public void pulseStart() {
+        ++pulseNumber;
+        fxPulseNumber = pulseNumber;
+        if (fxThread == null) {
+            fxThread = Thread.currentThread();
+        }
+        newPhase("Pulse start");
+    }
+
+    @Override
+    public void pulseEnd() {
+        newPhase(null);
+        fxPulseNumber = 0;
+    }
+
+    @Override
+    public void renderStart() {
+        renderPulseNumber = fxPulseNumber;
+    }
+
+    @Override
+    public void renderEnd() {
+        newPhase(null);
+        renderPulseNumber = 0;
+    }
+
+    /**
+     * Finishes the current phase and starts a new one if phaseName is not null.
+     *
+     * @param phaseName The name for the new phase.
+     */
+    @Override
+    public void newPhase(String phaseName) {
+        JFRPulsePhaseEvent event = currentPulsePhaseEvent.get();
+
+        /* Cleanup if no longer enabled */
+        if (!event.isEnabled()) {
+            event.setPhaseName(null);
+            return;
+        }
+
+        /* If there is an ongoing event, commit it */
+        if (event.getPhaseName() != null) {
+            event.commit();
+        }
+
+        /* Done if the new phase name is null */
+        if (phaseName == null) {
+            event.setPhaseName(null);
+            return;
+        }
+
+        event = new JFRPulsePhaseEvent();
+        event.begin();
+        event.setPhaseName(phaseName);
+        event.setPulseId(Thread.currentThread() == fxThread ? fxPulseNumber : renderPulseNumber);
+        currentPulsePhaseEvent.set(event);
+    }
+
+    @Override
+    public void newInput(String input) {
+        JFRInputEvent event = currentInputEvent.get();
+
+        /* Cleanup if no longer enabled */
+        if (!event.isEnabled()) {
+            event.setInput(null);
+            return;
+        }
+
+        /* If there is an ongoing event, commit it */
+        if (event.getInput() != null) {
+            event.commit();
+        }
+
+        /* Done if the new input is null */
+        if (input == null) {
+            event.setInput(null);
+            return;
+        }
+
+        event = new JFRInputEvent();
+        event.begin();
+        event.setInput(input);
+        currentInputEvent.set(event);
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulsePhaseEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulsePhaseEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.logging.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("javafx.PulsePhase")
+@Label("JavaFX Pulse Phase")
+@Category("JavaFX")
+@Description("Describes a phase in JavaFX pulse processing")
+@StackTrace(false)
+@Enabled(false)
+public final class JFRPulsePhaseEvent extends Event {
+    @PulseId
+    @Label("Pulse Id")
+    private int pulseId;
+
+    @Label("Phase Name")
+    private String phaseName;
+
+    public int getPulseId() {
+        return pulseId;
+    }
+
+    public void setPulseId(int pulseId) {
+        this.pulseId = pulseId;
+    }
+
+    public String getPhaseName() {
+        return phaseName;
+    }
+
+    public void setPhaseName(String phaseName) {
+        this.phaseName = phaseName;
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/PulseId.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/PulseId.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.logging.jfr;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jdk.jfr.Description;
+import jdk.jfr.Name;
+import jdk.jfr.Relational;
+
+/**
+ * This annotation defines a relation for future events that are related to the
+ * same pulse id. It also informs a user interface consuming events where a
+ * field contains a pulse id that the value could be useful to find other,
+ * related events.
+ */
+@Relational
+@Name("javafx.PulseId")
+@Retention(RUNTIME)
+@Target(FIELD)
+@Description("Binds events with same pulse id together")
+public @interface PulseId {
+
+}

--- a/modules/javafx.base/src/main/java/module-info.java
+++ b/modules/javafx.base/src/main/java/module-info.java
@@ -32,6 +32,7 @@
  */
 module javafx.base {
     requires java.desktop;
+    requires static jdk.jfr;
 
     exports javafx.beans;
     exports javafx.beans.binding;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javafx.scene.control.skin;
 
 import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.TreeShowingExpression;
 import com.sun.javafx.scene.control.skin.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -104,6 +105,7 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
     private IndeterminateSpinner spinner;
     private DeterminateIndicator determinateIndicator;
     private ProgressIndicator control;
+    private TreeShowingExpression treeShowingExpression;
 
     Animation indeterminateTransition;
 
@@ -125,12 +127,13 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
         super(control);
 
         this.control = control;
+        this.treeShowingExpression = new TreeShowingExpression(control);
 
         // register listeners
         registerChangeListener(control.indeterminateProperty(), e -> initialize());
         registerChangeListener(control.progressProperty(), e -> updateProgress());
-        registerChangeListener(NodeHelper.treeShowingProperty(control), e -> updateAnimation());
         registerChangeListener(control.sceneProperty(), e->updateAnimation());
+        registerChangeListener(treeShowingExpression, e -> updateAnimation());
 
         initialize();
         updateAnimation();
@@ -231,6 +234,8 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
     /** {@inheritDoc} */
     @Override public void dispose() {
         super.dispose();
+
+        treeShowingExpression.dispose();
 
         if (indeterminateTransition != null) {
             indeterminateTransition.stop();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
@@ -299,10 +299,6 @@ public abstract class NodeHelper {
         return nodeAccessor.isTreeShowing(node);
     }
 
-    public static BooleanExpression treeShowingProperty(Node node) {
-        return nodeAccessor.treeShowingProperty(node);
-    }
-
     public static List<Style> getMatchingStyles(CssMetaData cssMetaData, Styleable styleable) {
         return nodeAccessor.getMatchingStyles(cssMetaData, styleable);
     }
@@ -367,7 +363,6 @@ public abstract class NodeHelper {
         boolean isTreeVisible(Node node);
         BooleanExpression treeVisibleProperty(Node node);
         boolean isTreeShowing(Node node);
-        BooleanExpression treeShowingProperty(Node node);
         List<Style> getMatchingStyles(CssMetaData cssMetaData, Styleable styleable);
         Map<StyleableProperty<?>,List<Style>> findStyles(Node node,
                 Map<StyleableProperty<?>,List<Style>> styleMap);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingExpression.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingExpression.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene;
+
+import com.sun.javafx.binding.ExpressionHelper;
+import javafx.beans.InvalidationListener;
+import javafx.beans.binding.BooleanExpression;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.stage.Window;
+
+/**
+ * Used to observe changes in tree showing status for a {@link Node}.  For a Node's tree to be showing
+ * it must be visible, its ancestors must be visible, the node must be part of a {@link Scene} and
+ * the scene must have a {@link Window} which is currently showing.<p>
+ *
+ * This class provides the exact same functionality as {@link NodeHelper#isTreeShowing(Node)} in
+ * an observable form.
+ */
+public class TreeShowingExpression extends BooleanExpression {
+    private final ChangeListener<Boolean> windowShowingChangedListener = (obs, old, current) -> updateTreeShowing();
+    private final ChangeListener<Window> sceneWindowChangedListener = (obs, old, current) -> windowChanged(old, current);
+    private final ChangeListener<Scene> nodeSceneChangedListener = (obs, old, current) -> sceneChanged(old, current);
+
+    private final Node node;
+
+    private ExpressionHelper<Boolean> helper;
+    private boolean valid;
+    private boolean treeShowing;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param node a {@link Node} for which the tree showing status should be observed, cannot be null
+     */
+    public TreeShowingExpression(Node node) {
+        this.node = node;
+        this.node.sceneProperty().addListener(nodeSceneChangedListener);
+
+        NodeHelper.treeVisibleProperty(node).addListener(windowShowingChangedListener);
+
+        sceneChanged(null, node.getScene());
+    }
+
+    /**
+     * Cleans up any listeners that this class may have registered on the {@link Node}
+     * that was supplied at construction.
+     */
+    public void dispose() {
+        node.sceneProperty().removeListener(nodeSceneChangedListener);
+
+        NodeHelper.treeVisibleProperty(node).removeListener(windowShowingChangedListener);
+
+        valid = false;  // prevents unregistration from triggering an invalidation notification
+        sceneChanged(node.getScene(), null);
+    }
+
+    @Override
+    public void addListener(InvalidationListener listener) {
+        helper = ExpressionHelper.addListener(helper, this, listener);
+    }
+
+    @Override
+    public void removeListener(InvalidationListener listener) {
+        helper = ExpressionHelper.removeListener(helper, listener);
+    }
+
+    @Override
+    public void addListener(ChangeListener<? super Boolean> listener) {
+        helper = ExpressionHelper.addListener(helper, this, listener);
+    }
+
+    @Override
+    public void removeListener(ChangeListener<? super Boolean> listener) {
+        helper = ExpressionHelper.removeListener(helper, listener);
+    }
+
+    protected void invalidate() {
+        if (valid) {
+            valid = false;
+            ExpressionHelper.fireValueChangedEvent(helper);
+        }
+    }
+
+    @Override
+    public boolean get() {
+        if (!valid) {
+            updateTreeShowing();
+            valid = true;
+        }
+
+        return treeShowing;
+    }
+
+    private void sceneChanged(Scene oldScene, Scene newScene) {
+        if (oldScene != null) {
+            oldScene.windowProperty().removeListener(sceneWindowChangedListener);
+        }
+        if (newScene != null) {
+            newScene.windowProperty().addListener(sceneWindowChangedListener);
+        }
+
+        windowChanged(
+            oldScene == null ? null : oldScene.getWindow(),
+            newScene == null ? null : newScene.getWindow()
+        );
+    }
+
+    private void windowChanged(Window oldWindow, Window newWindow) {
+        if (oldWindow != null) {
+            oldWindow.showingProperty().removeListener(windowShowingChangedListener);
+        }
+        if (newWindow != null) {
+            newWindow.showingProperty().addListener(windowShowingChangedListener);
+        }
+
+        updateTreeShowing();
+    }
+
+    private void updateTreeShowing() {
+        boolean newValue = NodeHelper.isTreeShowing(node);
+
+        if (newValue != treeShowing) {
+            treeShowing = newValue;
+            invalidate();
+        }
+    }
+}

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -598,10 +598,6 @@ public abstract class Node implements EventTarget, Styleable {
                 return node.isTreeShowing();
             }
 
-            @Override
-            public BooleanExpression treeShowingProperty(Node node) {
-                return node.treeShowingProperty();
-            }
 
             @Override
             public List<Style> getMatchingStyles(CssMetaData cssMetaData,
@@ -1005,20 +1001,6 @@ public abstract class Node implements EventTarget, Styleable {
 
     private final InvalidationListener parentTreeVisibleChangedListener = valueModel -> updateTreeVisible(true);
 
-    private final ChangeListener<Boolean> windowShowingChangedListener
-            = (win, oldVal, newVal) -> updateTreeShowing();
-
-    private final ChangeListener<Window> sceneWindowChangedListener = (scene, oldWindow, newWindow) -> {
-        // Replace the windowShowingListener and call updateTreeShowing()
-        if (oldWindow != null) {
-            oldWindow.showingProperty().removeListener(windowShowingChangedListener);
-        }
-        if (newWindow != null) {
-            newWindow.showingProperty().addListener(windowShowingChangedListener);
-        }
-        updateTreeShowing();
-    };
-
     private SubScene subScene = null;
 
     /**
@@ -1079,26 +1061,6 @@ public abstract class Node implements EventTarget, Styleable {
             focusSetDirty(newScene);
         }
         scenesChanged(newScene, newSubScene, oldScene, oldSubScene);
-
-        // isTreeShowing needs to take into account of Window's showing
-        if (oldScene != null) {
-            oldScene.windowProperty().removeListener(sceneWindowChangedListener);
-
-            Window window = oldScene.windowProperty().get();
-            if (window != null) {
-                window.showingProperty().removeListener(windowShowingChangedListener);
-            }
-        }
-        if (newScene != null) {
-            newScene.windowProperty().addListener(sceneWindowChangedListener);
-
-            Window window = newScene.windowProperty().get();
-            if (window != null) {
-                window.showingProperty().addListener(windowShowingChangedListener);
-            }
-
-        }
-        updateTreeShowing();
 
         if (sceneChanged) reapplyCSS();
 
@@ -8429,69 +8391,8 @@ public abstract class Node implements EventTarget, Styleable {
         return w != null && w.isShowing();
     }
 
-    private void updateTreeShowing() {
-        setTreeShowing(isTreeVisible() && isWindowShowing());
-    }
-
-    private boolean treeShowing;
-    private TreeShowingPropertyReadOnly treeShowingRO;
-
-    final void setTreeShowing(boolean value) {
-        if (treeShowing != value) {
-            treeShowing = value;
-            ((TreeShowingPropertyReadOnly) treeShowingProperty()).invalidate();
-        }
-    }
-
     final boolean isTreeShowing() {
-        return treeShowingProperty().get();
-    }
-
-    final BooleanExpression treeShowingProperty() {
-        if (treeShowingRO == null) {
-            treeShowingRO = new TreeShowingPropertyReadOnly();
-        }
-        return treeShowingRO;
-    }
-
-    class TreeShowingPropertyReadOnly extends BooleanExpression {
-
-        private ExpressionHelper<Boolean> helper;
-        private boolean valid;
-
-        @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        protected void invalidate() {
-            if (valid) {
-                valid = false;
-                ExpressionHelper.fireValueChangedEvent(helper);
-            }
-        }
-
-        @Override
-        public boolean get() {
-            valid = true;
-            return Node.this.treeShowing;
-        }
-
+        return isTreeVisible() && isWindowShowing();
     }
 
     private void updateTreeVisible(boolean parentChanged) {
@@ -8510,8 +8411,6 @@ public abstract class Node implements EventTarget, Styleable {
             addToSceneDirtyList();
         }
         setTreeVisible(isTreeVisible);
-
-        updateTreeShowing();
     }
 
     private boolean treeVisible;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,10 +306,9 @@ public class SubScene extends Node {
                                 "is already set as root of another scene or subScene");
                     }
 
-                    // disabled, isTreeVisible and isTreeShowing properties are inherited
+                    // disabled and isTreeVisible properties are inherited
                     _value.setTreeVisible(isTreeVisible());
                     _value.setDisabled(isDisabled());
-                    _value.setTreeShowing(isTreeShowing());
 
                     if (oldRoot != null) {
                         StyleManager.getInstance().forget(SubScene.this);

--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javafx.stage;
 
+import com.sun.javafx.scene.TreeShowingExpression;
 import com.sun.javafx.util.Utils;
 import com.sun.javafx.event.DirectEvent;
 import java.util.ArrayList;
@@ -62,7 +63,7 @@ import com.sun.javafx.stage.WindowCloseRequestHandler;
 import com.sun.javafx.stage.WindowEventDispatcher;
 import com.sun.javafx.tk.Toolkit;
 import static com.sun.javafx.FXPermissions.CREATE_TRANSPARENT_WINDOW_PERMISSION;
-import com.sun.javafx.scene.NodeHelper;
+
 import com.sun.javafx.stage.PopupWindowHelper;
 import com.sun.javafx.stage.WindowHelper;
 import javafx.beans.property.ObjectPropertyBase;
@@ -149,6 +150,7 @@ public abstract class PopupWindow extends Window {
     };
 
     private WeakChangeListener<Boolean> weakOwnerNodeListener = new WeakChangeListener(changeListener);
+    private TreeShowingExpression treeShowingExpression;
 
     public PopupWindow() {
         final Pane popupRoot = new Pane();
@@ -410,7 +412,8 @@ public abstract class PopupWindow extends Window {
 
         // PopupWindow should disappear when owner node is not visible
         if (ownerNode != null) {
-            NodeHelper.treeShowingProperty(ownerNode).addListener(weakOwnerNodeListener);
+            treeShowingExpression = new TreeShowingExpression(ownerNode);
+            treeShowingExpression.addListener(weakOwnerNodeListener);
         }
 
         updateWindow(anchorX, anchorY);
@@ -487,7 +490,11 @@ public abstract class PopupWindow extends Window {
 
         // When popup hides, remove listeners; these are added when the popup shows.
         if (getOwnerWindow() != null) getOwnerWindow().showingProperty().removeListener(weakOwnerNodeListener);
-        if (getOwnerNode() != null) NodeHelper.treeShowingProperty(getOwnerNode()).removeListener(weakOwnerNodeListener);
+        if (treeShowingExpression != null) {
+            treeShowingExpression.removeListener(weakOwnerNodeListener);
+            treeShowingExpression.dispose();
+            treeShowingExpression = null;
+        }
     }
 
     /*

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/TreeShowingExpressionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/TreeShowingExpressionTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene;
+
+import com.sun.javafx.scene.TreeShowingExpression;
+import javafx.beans.InvalidationListener;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.SubScene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TreeShowingExpressionTest {
+    private final Parent root;
+    private final Node node;
+    private final TreeShowingExpression expression;
+
+    @Parameters
+    public static Collection<Object[]> parameters() {
+        Supplier<RootAndNodeToTest> supplier1 = () -> {
+            Node node = new StackPane();
+            return new RootAndNodeToTest(new StackPane(node), node);
+        };
+
+        Supplier<RootAndNodeToTest> supplier2 = () -> {
+            StackPane node = new StackPane();
+            return new RootAndNodeToTest(new StackPane(new SubScene(node, 100.0, 100.0)), node);
+        };
+
+        return Arrays.asList(new Object[][] { { supplier1 }, { supplier2 } });
+    }
+
+    static class RootAndNodeToTest {
+        RootAndNodeToTest(Parent root, Node nodeToTest) {
+            this.root = root;
+            this.nodeToTest = nodeToTest;
+        }
+
+        Parent root;
+        Node nodeToTest;
+    }
+
+    public TreeShowingExpressionTest(Supplier<RootAndNodeToTest> nodeSupplier) {
+        RootAndNodeToTest nodes = nodeSupplier.get();
+
+        this.root = nodes.root;
+        this.node = nodes.nodeToTest;
+        this.expression = new TreeShowingExpression(this.node);
+    }
+
+    @Test
+    public void nodeNotAttachedToSceneShouldNotBeShowing() {
+        assertFalse(expression.get());
+    }
+
+    @Test
+    public void getShouldTrackChangesInShowingStateForGivenNode() {
+        assertFalse(expression.get());  // not showing initially as not attached to a Scene
+
+        Scene scene = new Scene(root);
+
+        assertFalse(expression.get());  // not showing because Scene is not attached to a Window
+
+        Stage stage = new Stage();
+        stage.setScene(scene);
+
+        assertFalse(expression.get());  // not showing as Window is not shown
+
+        stage.show();
+
+        assertTrue(expression.get());  // showing as Window is shown
+
+        stage.hide();
+
+        assertFalse(expression.get());  // not showing again as Window is hidden
+    }
+
+    @Test
+    public void changeListenerShouldRegisterAndUnregisterCorrectly() {
+        AtomicReference<Boolean> state = new AtomicReference<>();
+        ChangeListener<Boolean> listener = (obs, old, current) -> state.set(current);
+
+        expression.addListener(listener);
+
+        assertNull(state.getAndSet(null));  // no change fired so far
+
+        Stage stage = new Stage();
+        stage.setScene(new Scene(root));
+        stage.show();
+
+        assertTrue(state.getAndSet(null));  // expect a change indicating the node is showing now
+
+        expression.removeListener(listener);
+
+        stage.hide();
+
+        assertNull(state.getAndSet(null));  // no change fired as listener was unregistered
+    }
+
+    @Test
+    public void invalidationListenerShouldRegisterAndUnregisterCorrectly() {
+        AtomicReference<Boolean> state = new AtomicReference<>();
+        InvalidationListener listener = obs -> state.set(true);
+
+        expression.addListener(listener);
+
+        assertNull(state.getAndSet(null));  // no invalidation fired so far
+
+        Stage stage = new Stage();
+        stage.setScene(new Scene(root));
+        stage.show();
+
+        assertTrue(state.getAndSet(null));  // expect an invalidation as node is showing now
+
+        expression.get();  // make valid again
+        expression.removeListener(listener);
+
+        stage.hide();
+
+        assertNull(state.getAndSet(null));  // expect no invalidation as listener was unregistered
+    }
+
+    @Test
+    public void changeListenerShouldTrackShowingState() {
+        AtomicReference<Boolean> state = new AtomicReference<>();
+
+        expression.addListener((obs, old, current) -> state.set(current));
+
+        assertNull(state.getAndSet(null));  // no change fired so far
+
+        Scene scene = new Scene(root);
+
+        assertNull(state.getAndSet(null));  // attaching to an invisible Scene fires no change
+
+        Stage stage = new Stage();
+        stage.setWidth(100);
+        stage.setHeight(100);
+        stage.setScene(scene);
+
+        assertNull(state.getAndSet(null));  // attaching to an invisible Scene fires no change
+
+        stage.show();
+
+        assertTrue(state.getAndSet(null));  // expect a change indicating the node is showing now
+
+        stage.setScene(null);
+
+        assertFalse(state.getAndSet(null));  // detaching stage from scene should fire not showing change
+
+        stage.setScene(scene);
+
+        assertTrue(state.getAndSet(null));  // reattaching stage should fire showing change
+
+        stage.hide();
+
+        assertFalse(state.getAndSet(null));  // expect a change indicating the node is no longer showing
+
+        Stage stage2 = new Stage();
+        stage2.setWidth(100);
+        stage2.setHeight(100);
+        stage2.show();
+        stage2.setScene(scene);
+
+        assertTrue(state.getAndSet(null));  // switching between invisible/visible Scene should trigger showing change
+
+        stage2.hide();
+
+        assertFalse(state.getAndSet(null));  // hiding attached window should trigger not showing change
+
+        stage.show();
+
+        assertNull(state.getAndSet(null));  // changing visibility of unattached stage should not do anything
+
+        scene.setRoot(new StackPane());
+        Scene scene2 = new Scene(root);
+        stage.setScene(scene2);
+
+        assertTrue(state.getAndSet(null));  // making root part of a different visible scene should trigger showing change
+    }
+
+    @Test
+    public void invalidationListenerShouldNotifyOfChangesInShowingState() {
+        AtomicReference<Boolean> state = new AtomicReference<>();
+
+        expression.addListener(obs -> state.set(true));
+
+        assertNull(state.getAndSet(null));  // no invalidation fired so far
+
+        Scene scene = new Scene(root);
+
+        assertNull(state.getAndSet(null));  // attaching to an invisible Scene fires no invalidation
+
+        Stage stage = new Stage();
+        stage.setWidth(100);
+        stage.setHeight(100);
+        stage.setScene(scene);
+
+        assertNull(state.getAndSet(null));  // attaching to an invisible Scene fires no invalidation
+
+        stage.show();
+
+        assertTrue(state.getAndSet(null));  // expect an invalidation as the node is showing now
+
+        expression.get();  // make valid
+        stage.setScene(null);
+
+        assertTrue(state.getAndSet(null));  // detaching stage from scene should fire invalidation
+
+        expression.get();  // make valid
+        stage.setScene(scene);
+
+        assertTrue(state.getAndSet(null));  // reattaching stage should fire invalidation
+
+        // didn't make valid here
+        stage.hide();
+
+        assertNull(state.getAndSet(null));  // expect nothing as expression still invalid
+
+        stage.show();
+        expression.get();  // make valid
+        stage.hide();
+
+        assertTrue(state.getAndSet(null));  // expect an invalidation as the node is no longer showing now
+
+        Stage stage2 = new Stage();
+        stage2.setWidth(100);
+        stage2.setHeight(100);
+        stage2.show();
+        expression.get();  // make valid
+        stage2.setScene(scene);
+
+        assertTrue(state.getAndSet(null));  // switching between invisible/visible Scene should trigger invalidation
+
+        expression.get();  // make valid
+        stage2.hide();
+
+        assertTrue(state.getAndSet(null));  // hiding attached window should trigger invalidation
+
+        expression.get();  // make valid
+        stage.show();
+
+        assertNull(state.getAndSet(null));  // changing visibility of unattached stage should not do anything
+
+        scene.setRoot(new StackPane());
+        Scene scene2 = new Scene(root);
+        expression.get();  // make valid
+        stage.setScene(scene2);
+
+        assertTrue(state.getAndSet(null));  // making root part of a different visible scene should trigger invalidation
+    }
+
+    @Test
+    public void disposeShouldUnregisterListenersOnGivenNode() {
+        AtomicReference<Boolean> state = new AtomicReference<>();
+
+        expression.addListener((obs, old, current) -> state.set(current));
+
+        // verify change listener works:
+        Stage stage = new Stage();
+        Scene scene = new Scene(root);
+        stage.setScene(scene);
+        stage.show();
+        assertTrue(state.getAndSet(null));
+
+        expression.dispose();
+
+        // verify change listener no longer responds:
+        stage.hide();
+        assertNull(state.getAndSet(null));
+
+        // another check:
+        Stage stage2 = new Stage();
+        stage2.setWidth(100);
+        stage2.setHeight(100);
+        stage2.show();
+        scene.setRoot(new StackPane());
+        stage2.setScene(new Scene(root));
+        assertNull(state.getAndSet(null));
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for regressions in performance of manipulating Nodes in a very large
+ * Scene (see JDK-8252935).
+ *
+ * Specifically, this test was created for the Tree Showing property which
+ * (before this fix) involved registering a listener to Scene and Window by
+ * each Node, causing large listeners lists on the Window property in Scene
+ * and the Showing property in Window.  The large lists of listeners would
+ * cause noticeable performance issues in Scenes with 10-20k+ Nodes (which
+ * for example can happen with a TableView with many visible small cells).
+ *
+ * The goal of this test is *NOT* to measure absolute performance, but to show
+ * that adding and removing Nodes (which involves registering and unregistering
+ * listeners) in a very large Scene does not take more than a particular
+ * threshold of time.
+ *
+ * The selected threshold is larger than actual observed time.
+ * It is not a benchmark value. It is good enough to catch the regression
+ * in performance, if any.
+ */
+
+public class NodeTreeShowingTest {
+
+    private static CountDownLatch startupLatch;
+    private static Stage stage;
+    private static BorderPane rootPane;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            stage = primaryStage;
+            rootPane = new BorderPane();
+            stage.setScene(new Scene(rootPane));
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> {
+                Platform.runLater(() -> startupLatch.countDown());
+            });
+            stage.show();
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(NodeTreeShowingTest.TestApp.class, (String[]) null)).start();
+
+        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    private StackPane createNodesRecursively(int count, int level) {
+        StackPane pane = new StackPane();
+
+        for (int i = 0; i < count; i++) {
+            pane.getChildren().add(level == 1 ? new StackPane() : createNodesRecursively(count, level - 1));
+        }
+
+        return pane;
+    }
+
+    /**
+     * This tests how quickly Nodes can be added and removed from a very large Scene.  Specifically,
+     * this test was created to ensure that not every Node in the Scene creates a listener on its
+     * Scene (and/or its associated Window).  With a large amount of Nodes in a Scene the listener
+     * lists of the associated Scene and/or Window can become very large and adding or removing
+     * a Node takes a performance hit.
+     */
+    @Test
+    public void testAddRemovalSpeedInHugeScene() throws Exception {
+        Random rnd = new Random(0);  // seed random to keep it predictable
+        int loopCount = 10000;
+        int levels = 13;
+        int nodesPerLevel = 2;  // total nodes is (nodesPerLevel ^ levels) * 2 - 1
+        int leafCount = (int)Math.pow(nodesPerLevel, levels);
+        int total = leafCount * 2 - 1;
+        StackPane testNode = new StackPane();
+        StackPane root = createNodesRecursively(nodesPerLevel, levels);
+        AtomicLong bestMillis = new AtomicLong(Long.MAX_VALUE);
+
+        Util.runAndWait(() -> {
+            rootPane.setCenter(root);
+        });
+
+        for (int j = 0; j < 5; j++) {
+            int loopNumber = j + 1;
+
+            Util.runAndWait(() -> {
+                // Compute time it takes to add/remove Nodes at random spots
+                long startTime = System.currentTimeMillis();
+
+                for (int i = 0; i < loopCount; i++) {
+                    // Find a random leaf to remove/re-add a child:
+                    int index = rnd.nextInt(leafCount);
+                    StackPane current = root;
+
+                    while (index >= nodesPerLevel) {
+                        current = (StackPane) current.getChildren().get(index % nodesPerLevel);
+                        index /= nodesPerLevel;
+                    }
+
+                    current.getChildren().add(current.getChildren().remove(index));
+                }
+
+                long endTime = System.currentTimeMillis();
+
+                bestMillis.set(Math.min(endTime - startTime, bestMillis.get()));
+
+                System.out.println("Loop " + loopNumber + ": Time to add/remove " + loopCount + " nodes in "
+                        + "a Scene consisting of " + total + " nodes = " + (endTime - startTime) + " mSec");
+            });
+        }
+
+        // NOTE : 800 mSec is not a benchmark value
+        // It is good enough to catch the regression in performance, if any
+        assertTrue("Time to add/remove " + loopCount + " nodes in a large Scene is more than 800 mSec (" + bestMillis.get() + ")", bestMillis.get() <= 800);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.runLater(() -> {
+            stage.hide();
+            Platform.exit();
+        });
+    }
+}


### PR DESCRIPTION
These are the optimizations that were already built by Paweł and tested on PSIpenta.

8088418: 
Only additional performance utils.
This is the issue fixed in Open JavaFX 12:
https://github.com/javafxports/openjdk-jfx/issues/261

We can expose JavaFX Pulse events in the form of Flight Recorder events (see [jdk.jfr package](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.jfr/jdk/jfr/package-summary.html)).
Then we can visualize them in JDK Mission Control:
http://missioncontrol.mcnz.com/2020/12/10/Profile_JavaFX_Performance_Flight_Recorder_Mission.html

8252935: 
This is a performance improvement especially important for scrolling in Tree tables/Tables with many columns.
This was fixed in Open JavaFX 12: https://bugs.openjdk.java.net/browse/JDK-8252935
Original pull request: https://github.com/openjdk/jfx/pull/185